### PR TITLE
Add threshold optimizer class and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,39 @@
-## Optimal Cut-Offs
+# Optimal Classification Cut-Offs
 
-Probabilities from classification models can have two problems: 
+This package helps you pick the best probability threshold for binary classifiers.
+Probabilistic models emit scores between 0 and 1, but the default threshold of 0.5 rarely
+produces the most useful predictions. `optimal_cut_offs` performs a simple brute-force search
+over candidate thresholds and returns the value that maximizes metrics such as accuracy or the F₁ score.
 
-1. Miscalibration: A p of .9 often doesn't mean a 90% chance of 1 (assuming a dichotomous y). (You can calibrate it using isotonic regression.)
+## Quick start
 
-2. Optimal cut-offs: For multi-class classifiers, we do not know what probability value will maximize the accuracy or F1 score. Or any metric for which you need to trade-off between FP and FN.
+```python
+from optimal_cut_offs import ThresholdOptimizer
 
-Here we share a solution for #2. It involves running the outputs through a brute-force optimizer. We provide a simple wrapper to make it yet easier to use.
+# true binary labels and predicted probabilities
+y_true = ...
+y_prob = ...
 
-### Function
-
-The function `get_probability` takes the following arguments: 
-
-1. `true_labs` (required): NumPy array or Pandas Series in which the true labels are stored. 
-2. `pred_prob` (required): NumPy array or Pandas Series in which the predicted probabilities are stored.
-3. `objective` (optional): `accuracy` (default) or `f1`
-4. `verbose` (optional): `True` or `False` (default) to show/hide verbose messages.
-
-The function outputs a numeric p-value that gives the lowest F1-score or FP+FN (max. accuracy).
-
-### Usage
-
-To use the [function](optimal_cut_offs.py), just download it and put it in the local directory and call import. 
-
-```
-import optimal_cut_offs
-
-df = ...
-
-p = optimal_cut_offs.get_probability(df.true_labs, df.pred_prob, 'accuracy')
-
+optimizer = ThresholdOptimizer(objective="f1")
+optimizer.fit(y_true, y_prob)
+y_pred = optimizer.predict(y_prob)
 ```
 
-### Illustration
+## API
 
-Check out this [Jupyter notebook](comscore.ipynb) to see the script in action. 
-For context, the notebook underlies the outputs you see [here](https://github.com/themains/domain_knowledge/blob/master/scripts/porn.ipynb).
+### `get_confusion_matrix(true_labs, pred_prob, prob)`
+Return counts of true/false positives and negatives for a probability threshold.
 
-### Authors
+### `get_probability(true_labs, pred_prob, objective='accuracy', verbose=False)`
+Brute-force search for the threshold that maximizes accuracy or F₁.
+
+### `ThresholdOptimizer(objective='accuracy', verbose=False)`
+Convenience wrapper around `get_probability` with `fit`/`predict` methods.
+
+## Examples
+
+- [Cross-validation and gradient methods](comscore.ipynb)
+
+## Authors
 
 Suriyan Laohaprapanon and Gaurav Sood

--- a/optimal_cut_offs.py
+++ b/optimal_cut_offs.py
@@ -1,8 +1,29 @@
+"""Utility functions for optimizing classification thresholds."""
+
 import numpy as np
 from scipy import optimize
 
 
 def _accuracy(prob, true_labs, pred_prob, verbose=False):
+    """Helper for brute-force search that returns `1 - accuracy`.
+
+    Parameters
+    ----------
+    prob : array_like
+        Candidate probability threshold provided by :func:`scipy.optimize.brute`.
+    true_labs : array_like
+        Array of true binary labels.
+    pred_prob : array_like
+        Predicted probabilities for the positive class.
+    verbose : bool, optional
+        If ``True``, prints intermediate accuracy values.
+
+    Returns
+    -------
+    float
+        ``1 - accuracy`` for the supplied ``prob``.
+    """
+
     tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob[0])
     accuracy = (tp + tn) / (tp + tn + fp + fn)
     if verbose:
@@ -11,6 +32,25 @@ def _accuracy(prob, true_labs, pred_prob, verbose=False):
 
 
 def _f1(prob, true_labs, pred_prob, verbose=False):
+    """Helper for brute-force search that returns ``1 - F1``.
+
+    Parameters
+    ----------
+    prob : array_like
+        Candidate probability threshold provided by :func:`scipy.optimize.brute`.
+    true_labs : array_like
+        Array of true binary labels.
+    pred_prob : array_like
+        Predicted probabilities for the positive class.
+    verbose : bool, optional
+        If ``True``, prints intermediate F1 values.
+
+    Returns
+    -------
+    float
+        ``1 - F1`` for the supplied ``prob``.
+    """
+
     tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob[0])
     precision = tp / (tp + fp)
     recall = tp / (tp + fn)
@@ -21,13 +61,30 @@ def _f1(prob, true_labs, pred_prob, verbose=False):
 
 
 def get_confusion_matrix(true_labs, pred_prob, prob):
+    """Compute confusion-matrix counts for a given probability threshold.
+
+    Parameters
+    ----------
+    true_labs : array_like
+        Array of true binary labels.
+    pred_prob : array_like
+        Predicted probabilities for the positive class.
+    prob : float
+        Probability threshold used to convert ``pred_prob`` into predicted labels.
+
+    Returns
+    -------
+    tuple
+        Counts of true positives, true negatives, false positives, and false negatives.
+    """
+
     pred_labs = pred_prob > prob
     # True Positive (TP): we predict a label of 1 (positive), and the true label is 1.
     tp = np.sum(np.logical_and(pred_labs == 1, true_labs == 1))
     # True Negative (TN): we predict a label of 0 (negative), and the true label is 0.
-    tn = np.sum(np.logical_and(pred_labs == 0, true_labs == 0))    
+    tn = np.sum(np.logical_and(pred_labs == 0, true_labs == 0))
     # False Positive (FP): we predict a label of 1 (positive), but the true label is 0.
-    fp = np.sum(np.logical_and(pred_labs == 1, true_labs == 0))    
+    fp = np.sum(np.logical_and(pred_labs == 1, true_labs == 0))
     # False Negative (FN): we predict a label of 0 (negative), but the true label is 1.
     fn = np.sum(np.logical_and(pred_labs == 0, true_labs == 1))
 
@@ -35,10 +92,92 @@ def get_confusion_matrix(true_labs, pred_prob, prob):
 
 
 def get_probability(true_labs, pred_prob, objective='accuracy', verbose=False):
+    """Find the probability threshold that optimizes a binary metric.
+
+    Parameters
+    ----------
+    true_labs : array_like
+        Array of true binary labels.
+    pred_prob : array_like
+        Predicted probabilities for the positive class.
+    objective : {'accuracy', 'f1'}, optional
+        Metric to optimize. Defaults to ``'accuracy'``.
+    verbose : bool, optional
+        If ``True``, prints intermediate metric values during the search.
+
+    Returns
+    -------
+    float
+        Probability threshold that minimizes ``1 - metric`` (i.e. maximizes the metric).
+    """
+
     if objective == 'accuracy':
-        prob = optimize.brute(_accuracy, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose)
+        prob = optimize.brute(
+            _accuracy, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose
+        )
     elif objective == 'f1':
-        prob = optimize.brute(_f1, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose)
+        prob = optimize.brute(
+            _f1, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose
+        )
     else:
         raise ValueError('`objective` must be `accuracy` or `f1`')
     return prob[0]
+
+
+class ThresholdOptimizer:
+    """Brute-force optimizer for classification thresholds.
+
+    Parameters
+    ----------
+    objective : {'accuracy', 'f1'}, optional
+        Metric to optimize. Defaults to ``'accuracy'``.
+    verbose : bool, optional
+        If ``True``, prints intermediate metric values during fitting.
+    """
+
+    def __init__(self, objective: str = 'accuracy', verbose: bool = False):
+        self.objective = objective
+        self.verbose = verbose
+        self.threshold_ = None
+
+    def fit(self, true_labs, pred_prob):
+        """Estimate the optimal threshold from labeled data.
+
+        Parameters
+        ----------
+        true_labs : array_like
+            Array of true binary labels.
+        pred_prob : array_like
+            Predicted probabilities for the positive class.
+
+        Returns
+        -------
+        ThresholdOptimizer
+            The fitted instance with ``threshold_`` attribute set.
+        """
+
+        self.threshold_ = get_probability(true_labs, pred_prob, self.objective, self.verbose)
+        return self
+
+    def predict(self, pred_prob):
+        """Convert probabilities to class predictions using learned threshold.
+
+        Parameters
+        ----------
+        pred_prob : array_like
+            Predicted probabilities for the positive class.
+
+        Returns
+        -------
+        numpy.ndarray
+            Boolean array of class predictions where ``True`` indicates the positive class.
+
+        Raises
+        ------
+        RuntimeError
+            If the optimizer has not been fitted yet.
+        """
+
+        if self.threshold_ is None:
+            raise RuntimeError('ThresholdOptimizer has not been fitted.')
+        return pred_prob > self.threshold_


### PR DESCRIPTION
## Summary
- document public API and introduce `ThresholdOptimizer` convenience class
- rewrite README overview with quick-start example and link to cross-validation notebook

## Testing
- `python -m py_compile optimal_cut_offs.py`


------
https://chatgpt.com/codex/tasks/task_e_68a23a3bdfc4832f8b4abe1af873cc91