### PR TITLE
Add packaging metadata and exports

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/optimal_cutoffs/__init__.py
+++ b/optimal_cutoffs/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for optimal classification cutoff utilities."""
+
+from optimal_cut_offs import get_confusion_matrix, get_probability
+
+__all__ = ["get_confusion_matrix", "get_probability"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "optimal-classification-cutoffs"
+version = "0.1.0"
+description = "Utilities for computing optimal classification cutoffs"
+readme = "README.md"
+license = {file = "LICENSE"}
+dependencies = [
+    "numpy",
+    "scipy",
+    "scikit-learn"
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"
+]
+
+[project.optional-dependencies]
+examples = ["matplotlib", "pandas"]
+
+[tool.setuptools]
+packages = ["optimal_cutoffs"]
+py-modules = ["optimal_cut_offs"]


### PR DESCRIPTION
## Summary
- add pyproject.toml with project metadata, dependencies, and optional extras
- expose confusion matrix and probability utilities in a package namespace
- include MIT license file

## Testing
- `python -m py_compile optimal_cutoffs/__init__.py optimal_cut_offs.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a23a23b904832f97666e14425d4464