### PR TITLE
Centralize metrics with registry and update threshold utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Optimal Cut-Offs
 
-Probabilities from classification models can have two problems: 
+Probabilities from classification models can have two problems:
 
 1. Miscalibration: A p of .9 often doesn't mean a 90% chance of 1 (assuming a dichotomous y). (You can calibrate it using isotonic regression.)
 
@@ -10,32 +10,35 @@ Here we share a solution for #2. It involves running the outputs through a brute
 
 ### Function
 
-The function `get_probability` takes the following arguments: 
+The function `get_optimal_threshold` takes the following arguments:
 
-1. `true_labs` (required): NumPy array or Pandas Series in which the true labels are stored. 
+1. `true_labs` (required): NumPy array or Pandas Series in which the true labels are stored.
 2. `pred_prob` (required): NumPy array or Pandas Series in which the predicted probabilities are stored.
-3. `objective` (optional): `accuracy` (default) or `f1`
+3. `objective` (optional): Name of the metric to optimize. Built-in objectives are `accuracy` and `f1`, and additional metrics can be registered via ``metrics.METRICS`` or the ``@metrics.register_metric`` decorator.
 4. `verbose` (optional): `True` or `False` (default) to show/hide verbose messages.
 
-The function outputs a numeric p-value that gives the lowest F1-score or FP+FN (max. accuracy).
+The function outputs a numeric p-value that gives the lowest F1-score or FP+FN (max. accuracy) depending on the objective chosen.
 
 ### Usage
 
-To use the [function](optimal_cut_offs.py), just download it and put it in the local directory and call import. 
+To use the [function](optimal_cut_offs.py), just download it and put it in the local directory and call import.
 
 ```
 import optimal_cut_offs
 
-df = ...
+# Optionally register a custom metric
+from metrics import METRICS, register_metric
 
-p = optimal_cut_offs.get_probability(df.true_labs, df.pred_prob, 'accuracy')
+@register_metric("custom")
+def my_metric(prob, true_labs, pred_prob, verbose=False):
+    return 0  # replace with your own metric
 
+p = optimal_cut_offs.get_optimal_threshold(df.true_labs, df.pred_prob, 'accuracy')
 ```
 
 ### Illustration
 
-Check out this [Jupyter notebook](comscore.ipynb) to see the script in action. 
-For context, the notebook underlies the outputs you see [here](https://github.com/themains/domain_knowledge/blob/master/scripts/porn.ipynb).
+Check out this [Jupyter notebook](comscore.ipynb) to see the script in action. For context, the notebook underlies the outputs you see [here](https://github.com/themains/domain_knowledge/blob/master/scripts/porn.ipynb).
 
 ### Authors
 

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,51 @@
+import numpy as np
+from typing import Callable, Dict
+
+# Registry mapping metric names to their corresponding functions
+METRICS: Dict[str, Callable] = {}
+
+def register_metric(name: str | None = None):
+    """Decorator to register a metric function.
+
+    Parameters
+    ----------
+    name: str | None
+        Optional name for the metric. If omitted the function's ``__name__`` is
+        used.
+    """
+    def decorator(func: Callable) -> Callable:
+        metric_name = name or func.__name__
+        METRICS[metric_name] = func
+        return func
+
+    return decorator
+
+
+def get_confusion_matrix(true_labs, pred_prob, prob):
+    """Compute the elements of the confusion matrix."""
+    pred_labs = pred_prob > prob
+    tp = np.sum(np.logical_and(pred_labs == 1, true_labs == 1))
+    tn = np.sum(np.logical_and(pred_labs == 0, true_labs == 0))
+    fp = np.sum(np.logical_and(pred_labs == 1, true_labs == 0))
+    fn = np.sum(np.logical_and(pred_labs == 0, true_labs == 1))
+    return tp, tn, fp, fn
+
+
+@register_metric("accuracy")
+def accuracy(prob, true_labs, pred_prob, verbose: bool = False):
+    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob[0])
+    acc = (tp + tn) / (tp + tn + fp + fn)
+    if verbose:
+        print(f"Probability: {prob[0]:0.4f} Accuracy: {acc:0.4f}")
+    return 1 - acc
+
+
+@register_metric("f1")
+def f1(prob, true_labs, pred_prob, verbose: bool = False):
+    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob[0])
+    precision = tp / (tp + fp)
+    recall = tp / (tp + fn)
+    score = 2 * precision * recall / (precision + recall)
+    if verbose:
+        print(f"Probability: {prob[0]:0.4f} F1 score: {score:0.4f}")
+    return 1 - score

--- a/optimal_cut_offs.py
+++ b/optimal_cut_offs.py
@@ -1,44 +1,21 @@
-import numpy as np
 from scipy import optimize
+from metrics import METRICS
 
 
-def _accuracy(prob, true_labs, pred_prob, verbose=False):
-    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob[0])
-    accuracy = (tp + tn) / (tp + tn + fp + fn)
-    if verbose:
-        print("Probability: {0:0.4f} Accuracy: {1:0.4f}".format(prob[0], accuracy))
-    return 1 - accuracy
-
-
-def _f1(prob, true_labs, pred_prob, verbose=False):
-    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob[0])
-    precision = tp / (tp + fp)
-    recall = tp / (tp + fn)
-    f1 = 2 * precision * recall / (precision + recall)
-    if verbose:
-        print("Probability: {0:0.4f} F1 score: {1:0.4f}".format(prob[0], f1))
-    return 1 - f1
-
-
-def get_confusion_matrix(true_labs, pred_prob, prob):
-    pred_labs = pred_prob > prob
-    # True Positive (TP): we predict a label of 1 (positive), and the true label is 1.
-    tp = np.sum(np.logical_and(pred_labs == 1, true_labs == 1))
-    # True Negative (TN): we predict a label of 0 (negative), and the true label is 0.
-    tn = np.sum(np.logical_and(pred_labs == 0, true_labs == 0))    
-    # False Positive (FP): we predict a label of 1 (positive), but the true label is 0.
-    fp = np.sum(np.logical_and(pred_labs == 1, true_labs == 0))    
-    # False Negative (FN): we predict a label of 0 (negative), but the true label is 1.
-    fn = np.sum(np.logical_and(pred_labs == 0, true_labs == 1))
-
-    return tp, tn, fp, fn
-
-
-def get_probability(true_labs, pred_prob, objective='accuracy', verbose=False):
-    if objective == 'accuracy':
-        prob = optimize.brute(_accuracy, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose)
-    elif objective == 'f1':
-        prob = optimize.brute(_f1, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose)
-    else:
-        raise ValueError('`objective` must be `accuracy` or `f1`')
+def get_optimal_threshold(true_labs, pred_prob, objective: str = "accuracy", verbose: bool = False):
+    """Find the probability threshold that optimizes a chosen metric."""
+    try:
+        metric = METRICS[objective]
+    except KeyError as exc:
+        raise ValueError(f"`objective` must be one of {list(METRICS)}") from exc
+    prob = optimize.brute(
+        metric,
+        (slice(0.1, 0.9, 0.1),),
+        args=(true_labs, pred_prob, verbose),
+        disp=verbose,
+    )
     return prob[0]
+
+
+# Backwards compatibility
+get_probability = get_optimal_threshold


### PR DESCRIPTION
## Summary
- add metrics registry with decorator for custom objectives
- move accuracy and f1 implementations to new metrics module
- update threshold utility to use registry and document usage

## Testing
- `python -m py_compile metrics.py optimal_cut_offs.py`
- `pip install numpy` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a23b200e20832fbf9e6e32d3598080