### PR TITLE
Add threshold optimization tests and utilities

### DIFF
--- a/optimal_cut_offs.py
+++ b/optimal_cut_offs.py
@@ -1,44 +1,86 @@
-import numpy as np
-from scipy import optimize
-
-
-def _accuracy(prob, true_labs, pred_prob, verbose=False):
-    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob[0])
-    accuracy = (tp + tn) / (tp + tn + fp + fn)
-    if verbose:
-        print("Probability: {0:0.4f} Accuracy: {1:0.4f}".format(prob[0], accuracy))
-    return 1 - accuracy
-
-
-def _f1(prob, true_labs, pred_prob, verbose=False):
-    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob[0])
-    precision = tp / (tp + fp)
-    recall = tp / (tp + fn)
-    f1 = 2 * precision * recall / (precision + recall)
-    if verbose:
-        print("Probability: {0:0.4f} F1 score: {1:0.4f}".format(prob[0], f1))
-    return 1 - f1
-
+"""Utilities for finding optimal probability thresholds without external deps."""
 
 def get_confusion_matrix(true_labs, pred_prob, prob):
-    pred_labs = pred_prob > prob
-    # True Positive (TP): we predict a label of 1 (positive), and the true label is 1.
-    tp = np.sum(np.logical_and(pred_labs == 1, true_labs == 1))
-    # True Negative (TN): we predict a label of 0 (negative), and the true label is 0.
-    tn = np.sum(np.logical_and(pred_labs == 0, true_labs == 0))    
-    # False Positive (FP): we predict a label of 1 (positive), but the true label is 0.
-    fp = np.sum(np.logical_and(pred_labs == 1, true_labs == 0))    
-    # False Negative (FN): we predict a label of 0 (negative), but the true label is 1.
-    fn = np.sum(np.logical_and(pred_labs == 0, true_labs == 1))
-
+    """Compute confusion matrix counts for a given threshold."""
+    pred_labs = [1 if p > prob else 0 for p in pred_prob]
+    tp = sum(1 for pl, tl in zip(pred_labs, true_labs) if pl == 1 and tl == 1)
+    tn = sum(1 for pl, tl in zip(pred_labs, true_labs) if pl == 0 and tl == 0)
+    fp = sum(1 for pl, tl in zip(pred_labs, true_labs) if pl == 1 and tl == 0)
+    fn = sum(1 for pl, tl in zip(pred_labs, true_labs) if pl == 0 and tl == 1)
     return tp, tn, fp, fn
 
+def precision_recall_f1(true_labs, pred_prob, prob):
+    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob)
+    precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+    recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+    return precision, recall, f1
+
+def accuracy(true_labs, pred_prob, prob):
+    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, prob)
+    total = tp + tn + fp + fn
+    return (tp + tn) / total if total > 0 else 0.0
+
+def get_optimal_threshold(true_labs, pred_prob, method='smart_brute', objective='f1'):
+    """Find the threshold maximizing the chosen metric."""
+    def metric(thr):
+        if objective == 'f1':
+            return precision_recall_f1(true_labs, pred_prob, thr)[2]
+        elif objective == 'accuracy':
+            return accuracy(true_labs, pred_prob, thr)
+        else:
+            raise ValueError('Unknown objective')
+    if method == 'smart_brute':
+        thresholds = [i / 100 for i in range(1, 100)]
+        return max(thresholds, key=metric)
+    elif method == 'minimize':
+        candidates = sorted(set(pred_prob))
+        candidates = [0.0] + candidates + [1.0]
+        midpoints = [(candidates[i] + candidates[i + 1]) / 2 for i in range(len(candidates) - 1)]
+        return max(midpoints, key=metric)
+    elif method == 'gradient':
+        thr = max([i / 100 for i in range(1, 100)], key=metric)
+        step = 0.1
+        while step > 1e-3:
+            improved = False
+            for cand in (thr - step, thr + step):
+                if 0 < cand < 1 and metric(cand) > metric(thr):
+                    thr = cand
+                    improved = True
+                    break
+            if not improved:
+                step /= 2
+        return thr
+    else:
+        raise ValueError('Unknown method')
+
+def cross_validate_thresholds(true_labs, pred_prob, method='smart_brute', objective='f1', k=5):
+    """Simple k-fold cross validation for threshold optimization."""
+    n = len(true_labs)
+    fold_sizes = [n // k + (1 if i < n % k else 0) for i in range(k)]
+    thresholds = []
+    scores = []
+    indices = list(range(n))
+    start = 0
+    for fold_size in fold_sizes:
+        stop = start + fold_size
+        test_idx = indices[start:stop]
+        train_idx = indices[:start] + indices[stop:]
+        train_true = [true_labs[i] for i in train_idx]
+        train_prob = [pred_prob[i] for i in train_idx]
+        test_true = [true_labs[i] for i in test_idx]
+        test_prob = [pred_prob[i] for i in test_idx]
+        thr = get_optimal_threshold(train_true, train_prob, method, objective)
+        thresholds.append(thr)
+        if objective == 'f1':
+            _, _, score = precision_recall_f1(test_true, test_prob, thr)
+        else:
+            score = accuracy(test_true, test_prob, thr)
+        scores.append(score)
+        start = stop
+    return thresholds, scores
 
 def get_probability(true_labs, pred_prob, objective='accuracy', verbose=False):
-    if objective == 'accuracy':
-        prob = optimize.brute(_accuracy, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose)
-    elif objective == 'f1':
-        prob = optimize.brute(_f1, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose)
-    else:
-        raise ValueError('`objective` must be `accuracy` or `f1`')
-    return prob[0]
+    """Backward compatible wrapper returning optimal probability."""
+    obj = 'accuracy' if objective == 'accuracy' else 'f1'
+    return get_optimal_threshold(true_labs, pred_prob, 'smart_brute', obj)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,16 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from optimal_cut_offs import get_confusion_matrix, precision_recall_f1
+
+
+def test_confusion_matrix_and_metrics():
+    true_labs = [1, 1, 0, 0]
+    pred_prob = [0.9, 0.2, 0.6, 0.4]
+    threshold = 0.5
+    tp, tn, fp, fn = get_confusion_matrix(true_labs, pred_prob, threshold)
+    assert (tp, tn, fp, fn) == (1, 1, 1, 1)
+    precision, recall, f1 = precision_recall_f1(true_labs, pred_prob, threshold)
+    assert precision == 0.5
+    assert recall == 0.5
+    assert f1 == 0.5

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,0 +1,31 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from optimal_cut_offs import get_optimal_threshold, cross_validate_thresholds
+
+
+def sample_data():
+    true_labs = [1, 0, 1, 1, 1]
+    pred_prob = [0.22, 0.205, 0.49, 0.9, 0.24]
+    return true_labs, pred_prob
+
+
+def test_get_optimal_threshold_methods():
+    true_labs, pred_prob = sample_data()
+    expected = 0.21
+    for method in ('smart_brute', 'minimize', 'gradient'):
+        threshold = get_optimal_threshold(true_labs, pred_prob, method)
+        assert abs(threshold - expected) < 0.01
+
+
+def test_cross_validation_ranges():
+    true_labs = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    pred_prob = [0.1, 0.9, 0.2, 0.8, 0.3, 0.7, 0.4, 0.6, 0.45, 0.55]
+    thresholds, scores = cross_validate_thresholds(true_labs, pred_prob, k=5)
+    assert len(thresholds) == 5
+    assert len(scores) == 5
+    for t in thresholds:
+        assert 0 <= t <= 1
+    for s in scores:
+        assert 0 <= s <= 1
+    assert sum(scores) / len(scores) > 0.8


### PR DESCRIPTION
## Summary
- Rewrite `optimal_cut_offs` to provide confusion matrix, precision/recall/F1, and threshold optimization without external deps
- Add tests for confusion matrix and metric calculations
- Add tests covering optimal threshold methods and cross-validation ranges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a23a117c28832f8c20e9823adbb4cd