### PR TITLE
Add tests for metrics and threshold optimizers

### DIFF
--- a/optimal_cutoffs/__init__.py
+++ b/optimal_cutoffs/__init__.py
@@ -1,5 +1,15 @@
 """Top-level package for optimal classification cutoff utilities."""
 
-from optimal_cut_offs import get_confusion_matrix, get_probability
+from optimal_cut_offs import (
+    get_confusion_matrix,
+    get_probability,
+    get_optimal_threshold,
+    cross_validate_thresholds,
+)
 
-__all__ = ["get_confusion_matrix", "get_probability"]
+__all__ = [
+    "get_confusion_matrix",
+    "get_probability",
+    "get_optimal_threshold",
+    "cross_validate_thresholds",
+]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from optimal_cut_offs import get_confusion_matrix
+
+
+def test_confusion_matrix_and_metrics():
+    y_true = np.array([0, 1, 1, 0, 1])
+    y_prob = np.array([0.2, 0.6, 0.7, 0.3, 0.4])
+    threshold = 0.5
+    tp, tn, fp, fn = get_confusion_matrix(y_true, y_prob, threshold)
+    assert (tp, tn, fp, fn) == (2, 2, 0, 1)
+
+    precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+    recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall)
+
+    assert precision == pytest.approx(1.0)
+    assert recall == pytest.approx(2 / 3)
+    assert f1 == pytest.approx(0.8)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from optimal_cut_offs import get_optimal_threshold, cross_validate_thresholds
+
+
+def test_get_optimal_threshold_methods():
+    y_true = np.array([0, 0, 0, 1, 1, 1])
+    y_prob = np.array([0.1, 0.2, 0.4, 0.6, 0.8, 0.9])
+    for method in ["smart_brute", "minimize", "gradient"]:
+        thr = get_optimal_threshold(y_true, y_prob, method=method)
+        assert 0.0 <= thr <= 1.0
+        assert thr == pytest.approx(0.5, abs=0.2)
+
+
+def test_cross_validate_thresholds():
+    rng = np.random.default_rng(0)
+    y_prob = rng.random(100)
+    y_true = (y_prob > 0.5).astype(int)
+    thresholds, scores = cross_validate_thresholds(
+        y_true, y_prob, method="smart_brute", cv=5, random_state=0
+    )
+    assert thresholds.shape == (5,)
+    assert scores.shape == (5,)
+    assert np.all((thresholds >= 0) & (thresholds <= 1))
+    assert np.all((scores >= 0) & (scores <= 1))


### PR DESCRIPTION
## Summary
- add flexible threshold optimizer with smart brute force, minimize, and gradient strategies
- support cross-validated threshold estimation
- test confusion-matrix metrics and new optimization methods

## Testing
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a23d9707c0832fa4c7330de304673e