### PR TITLE
Add threshold optimization examples

### DIFF
--- a/examples/advanced_usage.ipynb
+++ b/examples/advanced_usage.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced Threshold Optimization\n",
+    "This notebook demonstrates optimizing probability thresholds using synthetic data and scikit-learn." ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn.datasets import make_classification\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from optimal_cut_offs import ThresholdOptimizer, get_probability\n" ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X, y = make_classification(n_samples=200, n_features=5, random_state=0)\n",
+    "model = LogisticRegression().fit(X, y)\n",
+    "proba = model.predict_proba(X)[:, 1]\n" ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare thresholds for accuracy and F1\n",
+    "thr_acc = get_probability(y, proba, objective='accuracy')\n",
+    "thr_f1 = get_probability(y, proba, objective='f1')\n",
+    "print(f'Accuracy threshold: {thr_acc:.2f}')\n",
+    "print(f'F1 threshold: {thr_f1:.2f}')\n",
+    "opt = ThresholdOptimizer(objective='f1').fit(y, proba)\n",
+    "pred = opt.predict(proba)\n",
+    "print('Predictions sample:', pred[:10])\n" ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,21 @@
+"""Basic example demonstrating the optimal classification cutoff utilities."""
+
+import numpy as np
+from optimal_cut_offs import ThresholdOptimizer, get_confusion_matrix, get_probability
+
+# Simulated data
+y_true = np.array([0, 0, 1, 1, 0, 1, 0, 1, 0, 1])
+y_prob = np.array([0.1, 0.4, 0.35, 0.8, 0.7, 0.2, 0.9, 0.6, 0.3, 0.5])
+
+# Compute optimal threshold for accuracy
+best_threshold = get_probability(y_true, y_prob, objective="accuracy")
+print(f"Optimal threshold (accuracy): {best_threshold:.2f}")
+
+tp, tn, fp, fn = get_confusion_matrix(y_true, y_prob, best_threshold)
+print(f"Confusion matrix - TP: {tp}, TN: {tn}, FP: {fp}, FN: {fn}")
+
+# Using ThresholdOptimizer class
+optimizer = ThresholdOptimizer(objective="accuracy")
+optimizer.fit(y_true, y_prob)
+pred_labels = optimizer.predict(y_prob)
+print("Predictions:", pred_labels.astype(int))


### PR DESCRIPTION
## Summary
- Add an `examples` directory with a `basic_usage.py` script demonstrating how to compute an optimal classification threshold and generate predictions.
- Include an optional `advanced_usage.ipynb` notebook that showcases threshold optimization with `scikit-learn`.

## Testing
- `python examples/basic_usage.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -e .[examples]` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0, proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d5e86d8832faba582bc2fb09719