### PR TITLE
Add CI workflow for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[examples]
+          pip install ruff pytest
+      - name: Lint
+        run: ruff check . --exclude '*.ipynb'
+      - name: Test
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run ruff and pytest across Python 3.9-3.11

## Testing
- `pip install -e .[examples]` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `ruff check . --exclude '*.ipynb'`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a23eeae2a4832f9b5d0e31fa64cf49