### PR TITLE
Document public API and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Optimal Classification Cut-Offs
 
-This package helps you pick the best probability threshold for binary classifiers.
-Probabilistic models emit scores between 0 and 1, but the default threshold of 0.5 rarely
-produces the most useful predictions. `optimal_cut_offs` performs a simple brute-force search
-over candidate thresholds and returns the value that maximizes metrics such as accuracy or the F₁ score.
+Binary classifiers emit probabilities, but choosing a threshold of ``0.5`` often
+fails to maximize metrics such as accuracy or the F\ :sub:`1` score. This
+package provides utilities to **select an optimal probability threshold** for a
+given metric using brute-force search, numerical optimization, or gradient
+methods.
 
 ## Quick start
 
 ```python
-from optimal_cut_offs import ThresholdOptimizer
+from optimal_cutoffs import ThresholdOptimizer
 
 # true binary labels and predicted probabilities
 y_true = ...
@@ -21,18 +22,49 @@ y_pred = optimizer.predict(y_prob)
 
 ## API
 
-### `get_confusion_matrix(true_labs, pred_prob, prob)`
-Return counts of true/false positives and negatives for a probability threshold.
+### `get_confusion_matrix(true_labs, pred_prob, threshold)`
+- **Purpose:** Compute confusion-matrix counts for a threshold.
+- **Args:** arrays of true labels and probabilities, plus the decision threshold.
+- **Returns:** `(tp, tn, fp, fn)` counts.
+
+### `register_metric(name=None, func=None)`
+- **Purpose:** Add a metric function to the global registry.
+- **Args:** optional metric name and callable; can also be used as a decorator.
+- **Returns:** the registered function or decorator.
+
+### `register_metrics(metrics)`
+- **Purpose:** Register multiple metric functions at once.
+- **Args:** dictionary mapping names to callables.
+- **Returns:** `None`.
 
 ### `get_probability(true_labs, pred_prob, objective='accuracy', verbose=False)`
-Brute-force search for the threshold that maximizes accuracy or F₁.
+- **Purpose:** Brute-force search for the threshold that maximizes accuracy or F\ :sub:`1`.
+- **Args:** true labels, predicted probabilities, metric name, and verbosity flag.
+- **Returns:** optimal threshold.
+
+### `get_optimal_threshold(true_labs, pred_prob, metric='f1', method='smart_brute')`
+- **Purpose:** Optimize any registered metric using different strategies
+  (brute force, ``minimize``, or ``gradient``).
+- **Args:** true labels, probabilities, metric name, and optimization method.
+- **Returns:** optimal threshold.
+
+### `cv_threshold_optimization(true_labs, pred_prob, metric='f1', method='smart_brute', cv=5, random_state=None)`
+- **Purpose:** Estimate thresholds via cross-validation and report per-fold scores.
+- **Returns:** arrays of thresholds and scores.
+
+### `nested_cv_threshold_optimization(true_labs, pred_prob, metric='f1', method='smart_brute', inner_cv=5, outer_cv=5, random_state=None)`
+- **Purpose:** Perform nested cross-validation for threshold estimation and
+  unbiased performance evaluation.
+- **Returns:** arrays of outer-fold thresholds and scores.
 
 ### `ThresholdOptimizer(objective='accuracy', verbose=False)`
-Convenience wrapper around `get_probability` with `fit`/`predict` methods.
+- **Purpose:** High-level wrapper with ``fit``/``predict`` methods.
+- **Args:** metric name and verbosity flag.
+- **Returns:** fitted instance with ``threshold_`` attribute after calling ``fit``.
 
 ## Examples
 
-- [Cross-validation and gradient methods](comscore.ipynb)
+- [Cross-validation and gradient methods](examples/comscore.ipynb)
 
 ## Authors
 

--- a/optimal_cutoffs/cv.py
+++ b/optimal_cutoffs/cv.py
@@ -16,7 +16,29 @@ def cv_threshold_optimization(
     cv=5,
     random_state=None,
 ):
-    """Estimate thresholds via cross-validation and evaluate scores."""
+    """Estimate an optimal threshold using cross-validation.
+
+    Parameters
+    ----------
+    true_labs:
+        Array of true binary labels.
+    pred_prob:
+        Predicted probabilities from a classifier.
+    metric:
+        Metric name to optimize; must exist in the metric registry.
+    method:
+        Optimization strategy passed to
+        :func:`~optimal_cutoffs.optimizers.get_optimal_threshold`.
+    cv:
+        Number of folds for :class:`~sklearn.model_selection.KFold` cross-validation.
+    random_state:
+        Seed for the cross-validator shuffling.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, numpy.ndarray]
+        Arrays of per-fold thresholds and scores.
+    """
 
     kf = KFold(n_splits=cv, shuffle=True, random_state=random_state)
     thresholds = []
@@ -40,7 +62,31 @@ def nested_cv_threshold_optimization(
     outer_cv=5,
     random_state=None,
 ):
-    """Nested CV for threshold optimization and unbiased performance estimates."""
+    """Nested cross-validation for threshold optimization.
+
+    Parameters
+    ----------
+    true_labs:
+        Array of true binary labels.
+    pred_prob:
+        Predicted probabilities from a classifier.
+    metric:
+        Metric name to optimize.
+    method:
+        Optimization strategy passed to
+        :func:`~optimal_cutoffs.optimizers.get_optimal_threshold`.
+    inner_cv:
+        Number of folds in the inner loop used to estimate thresholds.
+    outer_cv:
+        Number of outer folds for unbiased performance assessment.
+    random_state:
+        Seed for the cross-validators.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, numpy.ndarray]
+        Arrays of outer-fold thresholds and scores.
+    """
 
     outer = KFold(n_splits=outer_cv, shuffle=True, random_state=random_state)
     outer_thresholds = []

--- a/optimal_cutoffs/metrics.py
+++ b/optimal_cutoffs/metrics.py
@@ -9,8 +9,20 @@ METRIC_REGISTRY: Dict[str, Callable[[int, int, int, int], float]] = {}
 def register_metric(name: str = None, func: Callable[[int, int, int, int], float] = None):
     """Register a metric function.
 
-    This can be used as a decorator or by passing ``name`` and ``func``
-    directly.
+    Parameters
+    ----------
+    name:
+        Optional key under which to store the metric. If not provided the
+        function's ``__name__`` is used.
+    func:
+        Metric callable accepting ``tp, tn, fp, fn``. When supplied the
+        function is registered immediately. If omitted, the returned decorator
+        can be used to annotate a metric function.
+
+    Returns
+    -------
+    Callable
+        The registered function or decorator.
     """
     if func is not None:
         METRIC_REGISTRY[name or func.__name__] = func
@@ -24,12 +36,35 @@ def register_metric(name: str = None, func: Callable[[int, int, int, int], float
 
 
 def register_metrics(metrics: Dict[str, Callable[[int, int, int, int], float]]):
-    """Register multiple metric functions from a dictionary."""
+    """Register multiple metric functions.
+
+    Parameters
+    ----------
+    metrics:
+        Mapping of metric names to callables that accept ``tp, tn, fp, fn``.
+
+    Returns
+    -------
+    None
+        This function mutates the global :data:`METRIC_REGISTRY` in-place.
+    """
     METRIC_REGISTRY.update(metrics)
 
 
 @register_metric("f1")
 def f1_score(tp: int, tn: int, fp: int, fn: int) -> float:
+    """Compute the F\ :sub:`1` score.
+
+    Parameters
+    ----------
+    tp, tn, fp, fn:
+        Elements of the confusion matrix.
+
+    Returns
+    -------
+    float
+        The harmonic mean of precision and recall.
+    """
     precision = tp / (tp + fp) if tp + fp > 0 else 0.0
     recall = tp / (tp + fn) if tp + fn > 0 else 0.0
     return 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
@@ -37,12 +72,39 @@ def f1_score(tp: int, tn: int, fp: int, fn: int) -> float:
 
 @register_metric("accuracy")
 def accuracy_score(tp: int, tn: int, fp: int, fn: int) -> float:
+    """Compute classification accuracy.
+
+    Parameters
+    ----------
+    tp, tn, fp, fn:
+        Elements of the confusion matrix.
+
+    Returns
+    -------
+    float
+        Ratio of correct predictions to total samples.
+    """
     total = tp + tn + fp + fn
     return (tp + tn) / total if total > 0 else 0.0
 
 
 def get_confusion_matrix(true_labs, pred_prob, prob):
-    """Compute confusion-matrix counts for a given probability threshold."""
+    """Compute confusion-matrix counts for a given threshold.
+
+    Parameters
+    ----------
+    true_labs:
+        Array of true binary labels.
+    pred_prob:
+        Array of predicted probabilities in ``[0, 1]``.
+    prob:
+        Decision threshold applied to ``pred_prob``.
+
+    Returns
+    -------
+    tuple[int, int, int, int]
+        Counts ``(tp, tn, fp, fn)``.
+    """
     pred_labs = pred_prob > prob
     tp = np.sum(np.logical_and(pred_labs == 1, true_labs == 1))
     tn = np.sum(np.logical_and(pred_labs == 0, true_labs == 0))

--- a/optimal_cutoffs/optimizers.py
+++ b/optimal_cutoffs/optimizers.py
@@ -27,7 +27,24 @@ def _f1(prob, true_labs, pred_prob, verbose=False):
 
 
 def get_probability(true_labs, pred_prob, objective="accuracy", verbose=False):
-    """Brute-force probability threshold search for simple metrics."""
+    """Brute-force search for a simple metric's best threshold.
+
+    Parameters
+    ----------
+    true_labs:
+        Array of true binary labels.
+    pred_prob:
+        Predicted probabilities from a classifier.
+    objective:
+        Metric to optimize. Supported values are ``"accuracy"`` and ``"f1"``.
+    verbose:
+        If ``True``, print intermediate metric values during the search.
+
+    Returns
+    -------
+    float
+        Threshold that maximizes the specified metric.
+    """
     if objective == "accuracy":
         prob = optimize.brute(
             _accuracy, (slice(0.1, 0.9, 0.1),), args=(true_labs, pred_prob, verbose), disp=verbose
@@ -52,7 +69,26 @@ def _metric_score(true_labs, pred_prob, threshold, metric="f1"):
 
 
 def get_optimal_threshold(true_labs, pred_prob, metric="f1", method="smart_brute"):
-    """Find the optimal threshold for a metric using different strategies."""
+    """Find the threshold that optimizes a metric.
+
+    Parameters
+    ----------
+    true_labs:
+        Array of true binary labels.
+    pred_prob:
+        Predicted probabilities from a classifier.
+    metric:
+        Name of a metric registered in :data:`~optimal_cutoffs.metrics.METRIC_REGISTRY`.
+    method:
+        Strategy used for optimization: ``"smart_brute"`` evaluates all unique
+        probabilities, ``"minimize"`` uses ``scipy.optimize.minimize_scalar``,
+        and ``"gradient"`` performs a simple gradient ascent.
+
+    Returns
+    -------
+    float
+        The threshold that maximizes the chosen metric.
+    """
     if method == "smart_brute":
         thresholds = np.unique(pred_prob)
         scores = [_metric_score(true_labs, pred_prob, t, metric) for t in thresholds]

--- a/optimal_cutoffs/wrapper.py
+++ b/optimal_cutoffs/wrapper.py
@@ -6,20 +6,57 @@ from .optimizers import get_probability
 
 
 class ThresholdOptimizer:
-    """Brute-force optimizer for classification thresholds."""
+    """Brute-force optimizer for classification thresholds.
+
+    The class wraps :func:`optimal_cutoffs.optimizers.get_probability` and
+    exposes a scikit-learn style ``fit``/``predict`` API.
+    """
 
     def __init__(self, objective: str = "accuracy", verbose: bool = False):
+        """Create a new optimizer.
+
+        Parameters
+        ----------
+        objective:
+            Metric to optimize, e.g. ``"accuracy"`` or ``"f1"``.
+        verbose:
+            If ``True``, print progress during threshold search.
+        """
         self.objective = objective
         self.verbose = verbose
         self.threshold_ = None
 
     def fit(self, true_labs, pred_prob):
-        """Estimate the optimal threshold from labeled data."""
+        """Estimate the optimal threshold from labeled data.
+
+        Parameters
+        ----------
+        true_labs:
+            Array of true binary labels.
+        pred_prob:
+            Predicted probabilities from a classifier.
+
+        Returns
+        -------
+        ThresholdOptimizer
+            Fitted instance with ``threshold_`` attribute set.
+        """
         self.threshold_ = get_probability(true_labs, pred_prob, self.objective, self.verbose)
         return self
 
     def predict(self, pred_prob):
-        """Convert probabilities to class predictions using learned threshold."""
+        """Convert probabilities to class predictions using the learned threshold.
+
+        Parameters
+        ----------
+        pred_prob:
+            Array of predicted probabilities to be thresholded.
+
+        Returns
+        -------
+        numpy.ndarray
+            Boolean array of predicted class labels.
+        """
         if self.threshold_ is None:
             raise RuntimeError("ThresholdOptimizer has not been fitted.")
         return pred_prob > self.threshold_


### PR DESCRIPTION
## Summary
- Explain optimal threshold selection for binary classifiers in README
- Add quick-start example and link to cross-validation/gradient demo
- Document all public functions and ThresholdOptimizer with detailed docstrings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a241986318832f8abcf1676f60b7f7