### PR TITLE
docs: update overview for multiclass cutoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Optimal Classification Cut-Offs
 
-Binary classifiers emit probabilities, but choosing a threshold of ``0.5`` often
-fails to maximize metrics such as accuracy or the F\ :sub:`1` score. This
-package provides utilities to **select an optimal probability threshold** for a
-given metric using brute-force search, numerical optimization, or gradient
-methods.
+Probabilistic classifiers output per-class probabilities, and fixed cutoffs such as ``0.5`` rarely maximize metrics like accuracy or the F\ :sub:`1` score.
+This package provides utilities to **select optimal probability cutoffs for each class**, supporting both multi-class and binary classifiers.
+Optimization methods include brute-force search, numerical techniques, and gradient-based approaches.
+Binary thresholding at a single cutoff remains fully supported as a special case.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- clarify README to cover class-specific cutoffs for multi-class and binary classifiers
- note that single-threshold binary classification remains supported
- mention brute-force, numerical, and gradient optimization methods in overview

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy scipy scikit-learn` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a2460c01e0832f8aa517e546f5791e