### PR TITLE
Ensure scalar minimization finds optimal threshold

### DIFF
--- a/optimal_cutoffs/optimizers.py
+++ b/optimal_cutoffs/optimizers.py
@@ -100,7 +100,13 @@ def get_optimal_threshold(true_labs, pred_prob, metric="f1", method="smart_brute
             bounds=(0, 1),
             method="bounded",
         )
-        return float(res.x)
+        # ``minimize_scalar`` may return a threshold that is suboptimal for
+        # piecewise-constant metrics like F1. To provide a more robust
+        # solution, also evaluate all unique predicted probabilities and pick
+        # whichever threshold yields the highest score.
+        candidates = np.unique(np.append(pred_prob, res.x))
+        scores = [_metric_score(true_labs, pred_prob, t, metric) for t in candidates]
+        return float(candidates[int(np.argmax(scores))])
 
     if method == "gradient":
         threshold = 0.5


### PR DESCRIPTION
## Summary
- Account for piecewise-constant metrics when optimizing threshold via `minimize_scalar`
- Evaluate unique predicted probabilities alongside the optimizer's result to choose the best threshold

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a24a380d08832fb8f50d8bcec1ed1c