### PR TITLE
Fix four silent-correctness defects: transposed cost matrix, skipped exact optimizer, dropped cost keys, optimistic CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ from optimal_cutoffs import metrics, bayes, cv, algorithms
 custom_f2 = lambda tp, tn, fp, fn: (5*tp) / (5*tp + 4*fn + fp)
 metrics.register("f2", custom_f2)
 
-# Cross-validation with threshold tuning
-thresholds = cv.cross_validate(model, X, y, metric="f1")
+# Cross-validation with threshold tuning (operates on labels and scores)
+thresholds, scores = cv.cross_validate(y_true, y_scores, metric="f1")
 
 # Advanced algorithms
 result = algorithms.multiclass.coordinate_ascent(y_true, y_scores)
@@ -219,12 +219,13 @@ print(f"Improvement: {improvement:+.1f}%")  # ~+40%
 ```python
 from optimal_cutoffs import cv
 
-# Cross-validation for threshold selection
-scores = cv.cross_validate(
-    model, X, y,
+# Cross-validation for threshold selection.
+# Returns (thresholds, scores): the threshold chosen on each fold's training part
+# and the metric it achieved on that fold's held-out part.
+thresholds, scores = cv.cross_validate(
+    y_true, y_scores,
     metric="f1",
     cv=5,
-    return_thresholds=True
 )
 ```
 

--- a/optimal_cutoffs/api.py
+++ b/optimal_cutoffs/api.py
@@ -404,7 +404,9 @@ def _optimize_binary(
         from .bayes import threshold as bayes_threshold
         from .core import OptimizationResult, Task
 
-        # Extract costs from utility dictionary
+        # Extract costs/benefits from utility dictionary. All four documented keys
+        # ("tp", "tn", "fp", "fn") enter the closed form
+        #   tau* = (u_tn - u_fp) / [(u_tp - u_fn) + (u_tn - u_fp)]
         util = utility or {}
         cost_fp = -util.get(
             "fp", 0
@@ -412,9 +414,16 @@ def _optimize_binary(
         cost_fn = -util.get(
             "fn", 0
         )  # Convert from utility (negative cost) to positive cost
+        benefit_tp = util.get("tp", 0)
+        benefit_tn = util.get("tn", 0)
 
         # Compute Bayes optimal threshold
-        optimal_thresh = bayes_threshold(cost_fp=cost_fp, cost_fn=cost_fn)
+        optimal_thresh = bayes_threshold(
+            cost_fp=cost_fp,
+            cost_fn=cost_fn,
+            benefit_tp=benefit_tp,
+            benefit_tn=benefit_tn,
+        )
 
         # Return OptimizationResult format
         def predict_fn(scores):

--- a/optimal_cutoffs/bayes_core.py
+++ b/optimal_cutoffs/bayes_core.py
@@ -381,11 +381,11 @@ def bayes_optimal_decisions(
     ----------
     probabilities : array of shape (n_samples, n_classes)
         Class probabilities (must be calibrated)
-    utility_matrix : array of shape (n_decisions, n_classes), optional
-        Utility matrix U[d,y] = utility(decision=d, true=y).
+    utility_matrix : array of shape (n_classes, n_decisions), optional
+        Utility matrix U[i,j] = utility(true class=i, decision=j).
         Higher values = better outcomes.
-    cost_matrix : array of shape (n_decisions, n_classes), optional
-        Cost matrix C[d,y] = cost(decision=d, true=y).
+    cost_matrix : array of shape (n_classes, n_decisions), optional
+        Cost matrix C[i,j] = cost of taking decision j when the true class is i.
         Lower values = better outcomes.
 
     Returns
@@ -437,8 +437,8 @@ def bayes_optimal_decisions(
     if utility.ndim != 2:
         raise ValueError("utility_matrix must be 2D array")
 
-    n_decisions = utility.shape[0]
-    n_classes = utility.shape[1]
+    n_classes = utility.shape[0]
+    n_decisions = utility.shape[1]
 
     # Handle case when probabilities are provided vs not
     if probabilities is not None:
@@ -452,9 +452,9 @@ def bayes_optimal_decisions(
                 f"utility_matrix has {n_classes}"
             )
 
-        # Compute expected utilities/costs: E[U|x] = Σ_y U(d,y) P(y|x)
+        # Compute expected utilities/costs: E[U|x, j] = Σ_i P(i|x) U(i, j)
         expected = (
-            probs @ utility.T
+            probs @ utility
         )  # (n_samples, n_classes) @ (n_classes, n_decisions) -> (n_samples, n_decisions)
 
         # Always maximize utility (whether provided directly or converted from costs)
@@ -473,7 +473,7 @@ def bayes_optimal_decisions(
             raise ValueError(f"Expected {n_classes} classes, got {p.shape[1]}")
 
         # Compute expected utilities and return optimal decisions (always maximize utility)
-        expected_new = p @ utility.T
+        expected_new = p @ utility
         return np.argmax(expected_new, axis=1).astype(np.int32)
 
     # For utility-based decisions, we don't have traditional "thresholds",

--- a/optimal_cutoffs/binary.py
+++ b/optimal_cutoffs/binary.py
@@ -153,8 +153,8 @@ def optimize_utility_binary(
     >>> # FN costs 5x more than FP
     >>> utility = {"tp": 10, "tn": 1, "fp": -1, "fn": -5}
     >>> result = optimize_utility_binary(None, y_score, utility=utility)
-    >>> result.threshold  # Closed-form optimal
-    0.167
+    >>> result.threshold  # (u_tn - u_fp) / [(u_tp - u_fn) + (u_tn - u_fp)] = 2/17
+    0.11764705882352941
     """
     from .bayes import BayesOptimal, UtilitySpec
 

--- a/optimal_cutoffs/core.py
+++ b/optimal_cutoffs/core.py
@@ -180,7 +180,12 @@ def select_method_with_explanation(
 
     match task:
         case Task.BINARY:
-            if metric in ["f1", "precision", "recall"]:
+            # sort_scan is exact for any metric that is piecewise-constant in the
+            # threshold and has a vectorized implementation. Consult the registry
+            # rather than a hardcoded list so custom metrics benefit too.
+            from .metrics_core import has_vectorized_implementation, is_piecewise_metric
+
+            if is_piecewise_metric(metric) and has_vectorized_implementation(metric):
                 notes.append(f"Using O(n log n) exact optimization for {metric}")
                 return "sort_scan", notes
             else:

--- a/optimal_cutoffs/cv/__init__.py
+++ b/optimal_cutoffs/cv/__init__.py
@@ -106,15 +106,33 @@ def cross_validate(
             result.threshold if result.task == Task.BINARY else result.thresholds
         )
 
-        # Evaluate on test set
-        test_result = optimize_thresholds(
-            y_test, score_test, metric=metric, **test_kwargs
-        )
-        score = (
-            test_result.score
-            if test_result.task == Task.BINARY
-            else np.mean(test_result.scores)
-        )
+        # Evaluate the training-fold threshold on the held-out fold. Re-optimising on
+        # the test fold would report that fold's own maximum, which is an optimistically
+        # biased estimate rather than a cross-validated one.
+        comparison = test_kwargs.get("comparison", ">")
+        test_weight = test_kwargs.get("sample_weight")
+        if result.task == Task.BINARY:
+            from ..metrics_core import compute_metric_at_threshold
+
+            score = compute_metric_at_threshold(
+                y_test,
+                score_test,
+                float(threshold),
+                metric=metric,
+                sample_weight=test_weight,
+                comparison=comparison,
+            )
+        else:
+            from ..metrics_core import multiclass_metric_single_label
+
+            score = multiclass_metric_single_label(
+                y_test,
+                score_test,
+                np.asarray(threshold),
+                metric,
+                comparison=comparison,
+                sample_weight=test_weight,
+            )
 
         thresholds.append(threshold)
         scores.append(score)

--- a/tests/algorithms/test_api_mode_parameters.py
+++ b/tests/algorithms/test_api_mode_parameters.py
@@ -241,13 +241,19 @@ class TestGoldenTests:
         y_prob = np.array([0.1, 0.3, 0.7, 0.8, 0.2, 0.9])
         utility = {"tp": 2, "tn": 1, "fp": -1, "fn": -5}
 
-        # Direct call to Bayes function (use negative costs to match utility convention)
-        result1 = bayes_threshold(cost_fp=1, cost_fn=5)
+        # Direct call to Bayes function. All four utility terms must be supplied: the
+        # closed form tau* = (u_tn - u_fp) / [(u_tp - u_fn) + (u_tn - u_fp)] depends on
+        # tp and tn as well as fp and fn.
+        result1 = bayes_threshold(
+            cost_fp=1, cost_fn=5, benefit_tp=utility["tp"], benefit_tn=utility["tn"]
+        )
 
         # Via optimize_thresholds API
         result2 = optimize_thresholds(None, y_prob, utility=utility, mode="bayes")
 
         assert abs(result1 - result2.threshold) < 1e-12
+        # (u_tn - u_fp) / [(u_tp - u_fn) + (u_tn - u_fp)] = 2 / (7 + 2) = 2/9
+        assert abs(result2.threshold - 2 / 9) < 1e-12
 
     def test_method_consistency(self):
         """Test that methods give consistent results."""

--- a/tests/algorithms/test_bayes_multiclass.py
+++ b/tests/algorithms/test_bayes_multiclass.py
@@ -24,8 +24,15 @@ class TestBayesDecisionFromUtilityMatrix:
     def test_with_abstain_option(self):
         """Test classification with abstain option."""
         y_prob = np.array([[0.4, 0.3, 0.3], [0.1, 0.8, 0.1]])
-        # Identity matrix plus abstain row with moderate utility
-        U = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [0.6, 0.6, 0.6]])
+        # Matrices are (n_classes, n_actions): U[i, j] = utility of action j when the
+        # true class is i. Actions 0-2 are the class predictions, action 3 is abstain.
+        U = np.array(
+            [
+                [1, 0, 0, 0.6],
+                [0, 1, 0, 0.6],
+                [0, 0, 1, 0.6],
+            ]
+        )
 
         result = optimize_decisions(y_prob, cost_matrix=-U)  # Negate for cost matrix
         decisions = result.predict(y_prob)
@@ -268,8 +275,9 @@ class TestBayesEdgeCases:
         with pytest.raises(ValueError, match="utility_matrix must be 2D array"):
             optimize_decisions(P, cost_matrix=-U_1d)
 
-        # Test mismatched shape
-        U_wrong = np.array([[1, 0, 0], [0, 1, 0]])  # 3 classes but P has 2
+        # Test mismatched shape. Matrices are (n_classes, n_actions), so a 3-row
+        # matrix declares 3 true classes while P supplies only 2.
+        U_wrong = np.array([[1, 0], [0, 1], [0, 0]])  # 3 classes but P has 2
         with pytest.raises(
             ValueError, match="probabilities has 2 classes but utility_matrix has 3"
         ):

--- a/tests/test_api_2_0.py
+++ b/tests/test_api_2_0.py
@@ -96,8 +96,22 @@ class TestExplainableAutoSelection:
         assert result.method == "sort_scan"
         assert any("O(n log n)" in note for note in result.notes)
 
-        # Accuracy should trigger minimize method
+        # Accuracy is also piecewise-constant with a vectorized implementation, so it
+        # gets the exact O(n log n) optimizer too.
         result = optimize_thresholds(y_true, y_score, method="auto", metric="accuracy")
+        assert result.method == "sort_scan"
+        assert any("O(n log n)" in note for note in result.notes)
+
+        # A metric registered without a piecewise/vectorized implementation falls back
+        # to scipy minimisation.
+        from optimal_cutoffs import metrics
+
+        metrics.register(
+            "_nonpiecewise_probe", lambda tp, tn, fp, fn: tp / (tp + fp + fn + 1e-9)
+        )
+        result = optimize_thresholds(
+            y_true, y_score, method="auto", metric="_nonpiecewise_probe"
+        )
         assert result.method == "minimize"
         assert any("scipy" in note for note in result.notes)
 

--- a/tests/test_documented_contracts.py
+++ b/tests/test_documented_contracts.py
@@ -1,0 +1,209 @@
+"""Tests that the implementation honours its own documented contracts.
+
+Each test here pins a behaviour that the package's README or docstrings state
+explicitly, and that was previously computed differently without any error or
+warning (silent wrongness).
+"""
+
+import numpy as np
+import pytest
+
+from optimal_cutoffs import optimize_decisions, optimize_thresholds
+from optimal_cutoffs.core import Task, select_method_with_explanation
+from optimal_cutoffs.metrics_core import (
+    has_vectorized_implementation,
+    is_piecewise_metric,
+)
+
+
+class TestCostMatrixOrientation:
+    """optimize_decisions documents cost_matrix[i, j] = cost of predicting j when true is i."""
+
+    def test_readme_cost_matrix_orientation(self):
+        """README example: [[0, 1], [10, 0]] means FN costs 10x more than FP.
+
+        With rows = true class:
+            C[0, 1] = 1  -> false positive costs 1
+            C[1, 0] = 10 -> false negative costs 10
+        Bayes rule predicts positive iff p >= c_fp / (c_fp + c_fn) = 1/11.
+        """
+        cost_matrix = np.array([[0.0, 1.0], [10.0, 0.0]])
+        p1 = np.array([0.02, 0.05, 0.09, 0.15, 0.30, 0.50, 0.80, 0.95])
+        y_score = np.column_stack([1 - p1, p1])
+
+        got = optimize_decisions(y_score, cost_matrix).predict(y_score)
+        expected = (p1 >= 1.0 / 11.0).astype(int)
+
+        np.testing.assert_array_equal(got, expected)
+
+    def test_cost_matrix_minimises_documented_cost(self):
+        """Decisions must minimise mean cost_matrix[true, pred], the documented semantics."""
+        rng = np.random.default_rng(0)
+        p = rng.uniform(0, 1, 20000)
+        scores = np.column_stack([1 - p, p])
+        y_true = (rng.uniform(size=p.size) < p).astype(int)
+
+        cost_matrix = np.array([[0.0, 1.0], [10.0, 0.0]])
+        dec = optimize_decisions(scores, cost_matrix).predict(scores)
+        cost_lib = cost_matrix[y_true, dec].mean()
+
+        best = min(
+            cost_matrix[y_true, (p >= tau).astype(int)].mean()
+            for tau in np.linspace(0, 1, 501)
+        )
+        # `best` is the in-sample minimum over a grid, so it slightly overfits the
+        # finite sample; the Bayes rule cannot beat it. Allow that sampling noise.
+        # Before the orientation fix this was 4.1845 vs 0.4451 -- a 9.4x excess.
+        assert cost_lib <= best + 0.01, (
+            f"library mean cost {cost_lib:.4f} exceeds best threshold rule {best:.4f}"
+        )
+
+    def test_asymmetric_three_class_cost_matrix(self):
+        """Rows are true classes: row i says what it costs to predict each j when truth is i."""
+        # Predicting class 0 is catastrophic when the truth is class 2.
+        cost_matrix = np.array(
+            [
+                [0.0, 1.0, 1.0],
+                [1.0, 0.0, 1.0],
+                [100.0, 1.0, 0.0],
+            ]
+        )
+        # Sample that is mostly class 0 but with a non-trivial chance of class 2.
+        probs = np.array([[0.60, 0.05, 0.35]])
+        got = optimize_decisions(probs, cost_matrix).predict(probs)
+
+        expected_cost = probs @ cost_matrix  # (1, n_actions), documented orientation
+        expected = np.argmin(expected_cost, axis=1)
+
+        np.testing.assert_array_equal(got, expected)
+        # Expected costs by action: 0 -> 0.35*100 + 0.05 = 35.05, 1 -> 0.60 + 0.35 = 0.95,
+        # 2 -> 0.60 + 0.05 = 0.65. The catastrophic true-car/predict-dog entry must push
+        # the decision away from action 0.
+        assert got[0] == 2
+
+
+class TestAutoSelectsExactMethodForPiecewiseMetrics:
+    """README: 'Exact solutions guaranteed for piecewise-constant metrics'."""
+
+    @pytest.mark.parametrize("metric", ["f1", "accuracy", "precision", "recall", "iou", "specificity"])
+    def test_auto_uses_sort_scan_for_piecewise_vectorized_metrics(self, metric):
+        assert is_piecewise_metric(metric) and has_vectorized_implementation(metric)
+        method, _ = select_method_with_explanation(Task.BINARY, metric, 100)
+        assert method == "sort_scan", (
+            f"{metric} is piecewise with a vectorized implementation but auto chose {method}"
+        )
+
+    @pytest.mark.parametrize("metric", ["accuracy", "iou", "specificity"])
+    def test_auto_matches_exact_optimum(self, metric):
+        """Default (auto) must not be beaten by the exact sort_scan optimizer."""
+        n_worse = 0
+        for seed in range(25):
+            rng = np.random.default_rng(seed)
+            y = rng.integers(0, 2, 200)
+            s = np.clip(rng.beta(2, 5, 200) + 0.3 * y, 0, 1)
+
+            auto = optimize_thresholds(y, s, metric=metric)
+            exact = optimize_thresholds(y, s, metric=metric, method="sort_scan")
+            if exact.scores[0] > auto.scores[0] + 1e-12:
+                n_worse += 1
+        assert n_worse == 0, f"auto was suboptimal for {metric} on {n_worse}/25 datasets"
+
+
+class TestCrossValidateReportsHeldOutScores:
+    """cv.cross_validate must evaluate the training-fold threshold on the held-out fold.
+
+    Re-optimising on the test fold reports that fold's own maximum, which is an
+    optimistically biased estimate rather than a cross-validated one.
+    """
+
+    def test_scores_correspond_to_returned_thresholds(self):
+        from sklearn.metrics import f1_score
+        from sklearn.model_selection import StratifiedKFold
+
+        from optimal_cutoffs import cv
+
+        rng = np.random.default_rng(0)
+        n = 400
+        y = rng.integers(0, 2, n)
+        s = np.clip(rng.beta(2, 5, n) + 0.35 * y, 0, 1)
+
+        thr, sc = cv.cross_validate(y, s, metric="f1", cv=5, random_state=0)
+
+        splitter = StratifiedKFold(n_splits=5, shuffle=True, random_state=0)
+        for (_, te), t, reported in zip(splitter.split(y, y), thr, sc, strict=True):
+            honest = f1_score(y[te], (s[te] > t).astype(int), zero_division=0)
+            assert reported == pytest.approx(honest, abs=1e-9), (
+                f"reported fold score {reported:.6f} != metric of returned "
+                f"threshold {t:.6f} on the held-out fold ({honest:.6f})"
+            )
+
+    def test_scores_are_not_test_fold_maxima(self):
+        """The reported score must not simply be the test fold's own optimum."""
+        from sklearn.metrics import f1_score
+        from sklearn.model_selection import StratifiedKFold
+
+        from optimal_cutoffs import cv
+
+        rng = np.random.default_rng(0)
+        n = 400
+        y = rng.integers(0, 2, n)
+        s = np.clip(rng.beta(2, 5, n) + 0.35 * y, 0, 1)
+
+        thr, sc = cv.cross_validate(y, s, metric="f1", cv=5, random_state=0)
+        splitter = StratifiedKFold(n_splits=5, shuffle=True, random_state=0)
+
+        test_optima = [
+            max(
+                f1_score(y[te], (s[te] > c).astype(int), zero_division=0)
+                for c in np.unique(s[te])
+            )
+            for _, te in splitter.split(y, y)
+        ]
+        # A held-out score can coincidentally equal the fold optimum, but not on every
+        # fold of a dataset with this much threshold variation.
+        assert not np.allclose(sc, test_optima), (
+            "every fold's reported score equals that fold's own optimum, "
+            "indicating the threshold was re-fit on the test data"
+        )
+
+
+class TestBayesModeUsesAllDocumentedUtilityKeys:
+    """optimize_thresholds documents utility keys 'tp', 'tn', 'fp', 'fn' for mode='bayes'."""
+
+    def test_bayes_mode_honours_tp_and_tn(self):
+        utility = {"tp": 10.0, "tn": 1.0, "fp": -1.0, "fn": -5.0}
+        u_tp, u_tn, u_fp, u_fn = 10.0, 1.0, -1.0, -5.0
+        expected = (u_tn - u_fp) / ((u_tp - u_fn) + (u_tn - u_fp))
+
+        p = np.linspace(0.01, 0.99, 200)
+        got = optimize_thresholds(None, p, mode="bayes", utility=utility).threshold
+
+        assert got == pytest.approx(expected, abs=1e-9), (
+            f"mode='bayes' returned {got:.6f}, closed form is {expected:.6f}"
+        )
+
+    def test_bayes_mode_agrees_with_empirical_utility_path(self):
+        """The same utility dict must give the same closed-form threshold either way."""
+        utility = {"tp": 10.0, "tn": 1.0, "fp": -1.0, "fn": -5.0}
+        rng = np.random.default_rng(0)
+        p = rng.uniform(0, 1, 5000)
+        y = (rng.uniform(size=p.size) < p).astype(int)
+
+        t_bayes = optimize_thresholds(None, p, mode="bayes", utility=utility).threshold
+        t_emp = optimize_thresholds(y, p, utility=utility).threshold
+
+        assert t_bayes == pytest.approx(t_emp, abs=1e-9)
+
+    def test_bayes_mode_tp_tn_actually_change_the_threshold(self):
+        """Changing the documented tp/tn keys must move the threshold."""
+        base = {"tp": 0.0, "tn": 0.0, "fp": -1.0, "fn": -5.0}
+        richer = {"tp": 20.0, "tn": 0.0, "fp": -1.0, "fn": -5.0}
+
+        p = np.linspace(0.01, 0.99, 100)
+        t_base = optimize_thresholds(None, p, mode="bayes", utility=base).threshold
+        t_rich = optimize_thresholds(None, p, mode="bayes", utility=richer).threshold
+
+        assert t_rich < t_base, (
+            "raising the true-positive benefit must lower the threshold, "
+            f"got {t_rich:.6f} vs {t_base:.6f}"
+        )


### PR DESCRIPTION
Four defects, every one of them silent: a plausible number that is wrong, with no error
and no warning. Each fix ships with a test confirmed to fail without it.

## 1. The cost matrix was read transposed

`README.md:89` says `# Cost matrix: rows=true class, cols=predicted class`. The function's
own docstring states the rule it implements as `argmin_j Σ_i p_i * C(i,j)`, and describes
costs that "depend on both true class i and predicted class j". With `p` a row vector over
`i` and `C[i,j]`, that sum is `probs @ C`. The code computed `probs @ C.T`.

Only the parameter line said otherwise. Running the README's own example verbatim --
`[[0, 1], [10, 0]]`, "false negatives cost 10x more than false positives":

```
p(class 1)  0.02 0.05 0.08 0.10 0.15 0.30 0.60 0.95
decision       0    0    0    0    0    0    0    1     <- as shipped
correct        0    0    0    1    1    1    1    1     <- Bayes threshold 1/11 = 0.0909

mean cost of the returned rule: 1.6313      best achievable: 0.5500
```

Three times the achievable cost, and the rule flips at the wrong place entirely. A
symmetric cost matrix hides it completely, which is why tests built on `np.eye(3)` passed.

## 2. `method="auto"` skipped the exact optimizer for three metrics

The registry marks `accuracy`, `iou` and `specificity` as piecewise-constant with
vectorized implementations, and exposes `is_piecewise_metric()` /
`has_vectorized_implementation()` to ask. The router instead tested a hardcoded
`["f1", "precision", "recall"]`.

Over 200 datasets the default was suboptimal for **accuracy 116/200, iou 154/200,
specificity 48/200** -- against a README that promises "Exact solutions guaranteed for
piecewise-constant metrics", with no warning that a different method was used.

## 3. `mode="bayes"` silently dropped two of its four documented cost keys

It read only `fp` and `fn`; `benefit_tp` and `benefit_tn` stayed at 0. For
`{"tp": 10, "tn": 1, "fp": -1, "fn": -5}` it returned 0.1667 where the closed form
`(u_tn - u_fp) / [(u_tp - u_fn) + (u_tn - u_fp)]` gives 2/17 = 0.1176. A 200k-sample
expected-utility grid search puts the argmax at 0.1184, confirming the closed form.

The same dict through the empirical path already returned 0.1176 -- two documented routes
to the same quantity, disagreeing.

## 4. `cross_validate` reported test-fold maxima, not held-out scores

The "evaluate on test set" step called `optimize_thresholds` **again on the test fold**, so
the reported score was that fold's own optimum and the returned threshold never entered
it. `reported == test-fold optimum` held exactly.

```
reported CV F1 over 5 folds:   0.7018   (as shipped)
                               0.6510   (applying the training-fold threshold)
```

An optimistic bias of about +0.05. These are numbers that go into papers.

## It is not actually a convention call

I originally flagged the orientation as a judgement call, since it pits the documentation
against the implementation. It is not. The transposed reading violates a property that must
hold for **any** valid cost matrix, independent of which orientation anyone intended.

Adding a constant `c` to row `i` of `C` adds `Σᵢ pᵢ cᵢ` to the expected cost of **every**
decision `j`, because the sum runs over `i`. The argmin over `j` therefore cannot move. On
a deliberately asymmetric 3x3 matrix and 150 samples:

```
                    rows = true class      transposed (as shipped)
  row 0 + 10        0 of 150 changed        9 of 150 changed
  row 1 + 10        0 of 150 changed       78 of 150 changed
  row 2 + 10        0 of 150 changed       63 of 150 changed
```

Under the transposed reading the shift lands on a single decision instead of being spread
across all of them, so the argmin moves. No appeal to the README is needed.

The same battery confirms the other invariants hold after the fix: scaling `C` by any
positive constant leaves decisions unchanged, permuting decision columns permutes the
decisions correspondingly, and a zero diagonal with equal off-diagonals reduces exactly to
`argmax p`.

## The four tests that changed

Four existing tests are updated. Two of them are independent evidence for the other
defects rather than casualties of this one:

- The "golden" Bayes test called `bayes_threshold(cost_fp=1, cost_fn=5)` and compared it
  against a utility dict carrying `tp=2, tn=1`. Those agree **only if tp and tn are
  dropped** -- it was pinning defect 3. It now supplies all four terms and asserts the
  closed form 2/9.
- The routing test asserted "accuracy should trigger minimize method" -- it was pinning
  defect 2. It now asserts `sort_scan`.

The other two are transposes consistent with defect 1: a (4,3) utility matrix for a
3-class problem with an abstain action becomes (3,4), and a shape-validation matrix whose
intent is "3 classes but P has 2" becomes 3 rows instead of 3 columns.

## Investigated and refuted

Recorded because they were suspected and are not defects: the `bayes.threshold` closed
form is correct (derived independently; limiting cases, monotonicity in both cost
directions and the documented `thresholds_from_costs` values all pass); `metrics.register`
works; `algorithms.multiclass.coordinate_ascent` exists; bogus kwargs raise `TypeError`
rather than being swallowed; and multiclass `independent` returning `(n, K)` indicators is
explicitly documented as "can predict multiple classes", so it is intended.

The sort_scan core came through a full battery clean: self-consistency, argmax-vs-grid,
determinism, row-permutation invariance, monotone-transform invariance, unit-weight and
duplication-weight identities, ties, separable and single-class data.

## Not checked

Multiclass `coord_ascent` optimality has no independent exact reference here -- only
determinism, invariance and single-label output were verified. The numba path,
the scikit-optimize `adaptive` path, and `nested_cross_validate` were not exercised; the
last may share defect 4's re-optimization pattern and is worth a look.

## Tests

588 -> **605 passed**, 54 skipped, no pre-existing failures to misattribute. Reverting each
source file individually fails only its own tests: `core.py` 6, `bayes_core.py` 3,
`api.py` 3, `cv/__init__.py` 2. `ruff check .` passes.

